### PR TITLE
feat: add git worktree support (-w flag)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "try-rs"
-version = "0.1.41"
+version = "0.1.42"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "try-rs"
-version = "0.1.41"
+version = "0.1.42"
 authors = ["Tassio Virginio <tassio.virginio@gmail.com>"]
 homepage = "https://github.com/tassiovirginio/try-rs"
 edition = "2024"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+try-rs (0.1.42-1) noble; urgency=medium
+
+  * Add git worktree support.
+
+ -- Tassio Virginio <tassiovirginio@gmail.com>  Tue, 20 Jan 2026 19:27:43 -0300
+
 try-rs (0.1.41-1) noble; urgency=medium
 
   * fix: respect TRY_CONFIG_DIR for shell integration paths

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@ description = "try-rs: Temporary workspace manager with TUI";
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "try-rs";
-          version = "0.1.41";  # atualize quando lançar nova
+          version = "0.1.42";  # atualize quando lançar nova
 
           src = self;  # usa o próprio repo como source
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,21 +5,25 @@ use clap::{Parser, ValueEnum};
 #[command(about = format!("🦀 try-rs {} 🦀\nA blazing fast, Rust-based workspace manager for your temporary experiments.", env!("CARGO_PKG_VERSION")), long_about = None)]
 #[command(version = env!("CARGO_PKG_VERSION"))]
 pub struct Cli {
-    /// Create or jump to an experiment / Clone a repo. Starts the TUI (Terminal User Interface) if omitted.
+    /// Create or jump to an experiment / Clone a git URL. Starts TUI if omitted
     #[arg(value_name = "NAME_OR_URL")]
     pub name_or_url: Option<String>,
 
-    /// Destination folder name (optional)
+    /// Destination folder name when cloning a repository
     #[arg(value_name = "DESTINATION")]
     pub destination: Option<String>,
 
-    /// Generate shell integration code
+    /// Generate shell integration code for the specified shell
     #[arg(long)]
     pub setup: Option<Shell>,
 
-    /// Shallow clone
+    /// Use shallow clone (--depth 1) when cloning repositories
     #[arg(short, long)]
     pub shallow_clone: bool,
+
+    /// Create a git worktree from current repository (must be inside a git repo)
+    #[arg(short = 'w', long = "worktree", value_name = "WORKTREE_NAME")]
+    pub worktree: Option<String>,
 }
 
 #[derive(ValueEnum, Clone, Copy, PartialEq, Eq, Debug)]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -32,6 +32,7 @@ pub struct TryEntry {
     pub created: SystemTime,
     pub score: i64,
     pub is_git: bool,
+    pub is_worktree: bool,
     pub is_mise: bool,
     pub is_cargo: bool,
     pub is_maven: bool,
@@ -75,7 +76,9 @@ impl App {
                     && metadata.is_dir()
                 {
                     let name = entry.file_name().to_string_lossy().to_string();
-                    let is_git = entry.path().join(".git").exists();
+                    let git_path = entry.path().join(".git");
+                    let is_git = git_path.exists();
+                    let is_worktree = git_path.is_file();
                     let is_mise = entry.path().join("mise.toml").exists();
                     let is_cargo = entry.path().join("Cargo.toml").exists();
                     let is_maven = entry.path().join("pom.xml").exists();
@@ -89,6 +92,7 @@ impl App {
                         created: metadata.created().unwrap_or(SystemTime::UNIX_EPOCH),
                         score: 0,
                         is_git,
+                        is_worktree,
                         is_mise,
                         is_cargo,
                         is_maven,
@@ -434,6 +438,8 @@ pub fn run_app(
                     let date_width = date_text.chars().count();
                     let git_icon = if entry.is_git { " " } else { "" };
                     let git_width = if entry.is_git { 2 } else { 0 };
+                    let worktree_icon = if entry.is_worktree { "󰙅" } else { "" };
+                    let worktree_width = if entry.is_worktree { 2 } else { 0 };
                     let mise_icon = if entry.is_mise { "󰬔 " } else { "" };
                     let mise_width = if entry.is_mise { 2 } else { 0 };
                     let cargo_icon = if entry.is_cargo { " " } else { "" };
@@ -454,6 +460,7 @@ pub fn run_app(
 
                     let reserved = date_width
                         + git_width
+                        + worktree_width
                         + mise_width
                         + cargo_width
                         + maven_width
@@ -480,6 +487,7 @@ pub fn run_app(
                                     + name_len
                                     + date_width
                                     + git_width
+                                    + worktree_width
                                     + mise_width
                                     + cargo_width
                                     + maven_width
@@ -501,6 +509,10 @@ pub fn run_app(
                         Span::styled(go_icon, Style::default().fg(Color::Rgb(0, 173, 216))),
                         Span::styled(python_icon, Style::default().fg(Color::Yellow)),
                         Span::styled(mise_icon, Style::default().fg(Color::Rgb(250, 179, 135))),
+                        Span::styled(
+                            worktree_icon,
+                            Style::default().fg(Color::Rgb(100, 180, 100)),
+                        ),
                         Span::styled(git_icon, Style::default().fg(Color::Rgb(240, 80, 50))),
                         Span::styled(date_text, Style::default().fg(app.theme.list_date)),
                     ]);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,14 @@
 use std::path::PathBuf;
+use std::process::Command;
+
+/// Verifica se o diretório atual está dentro de um repositório git
+pub fn is_inside_git_repo() -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
 
 pub fn expand_path(path_str: &str) -> PathBuf {
     if (path_str.starts_with("~/") || (cfg!(windows) && path_str.starts_with("~\\")))


### PR DESCRIPTION
- Add -w/--worktree flag to create git worktrees from current repository
- Add is_inside_git_repo() utility function for git repo detection
- Display worktree icon in TUI folder list for worktree directories
- Improve CLI help descriptions for all options
- Bump version to 0.1.42