### PR TITLE
make git worktree command’s output go to our stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn main() -> Result<()> {
 
         let status = std::process::Command::new("git")
             .args(["worktree", "add", new_path.to_str().unwrap()])
-            .stdout(Stdio::inherit())
+            .stdout(std::io::stderr())
             .stderr(Stdio::inherit())
             .status();
 


### PR DESCRIPTION
so that the shell wrapper that evaluates our stdout doesn’t try to evaluate git's output.

Fixes #25