### PR TITLE
ignore keys with modifiers if they aren’t a valid key binding

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -677,7 +677,9 @@ pub fn run_app(
                         } else if c == 'u' && key.modifiers.contains(event::KeyModifiers::CONTROL) {
                             app.query.clear();
                             app.update_search();
-                        } else {
+                        } else if key.modifiers.is_empty()
+                            || key.modifiers == event::KeyModifiers::SHIFT
+                        {
                             app.query.push(c);
                             app.status_message = None;
                             app.update_search();


### PR DESCRIPTION
So that Control-x doesn't type an x into the search box, for instance, but typing ‘x’ or ‘X’ still does.