### PR TITLE
optionally add current date prefix and parse creation date from folder name in list view

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ By default, experiments are stored in `~/work/tries`. You can customize the path
 # config.toml
 tries_path = "~/Development/playground"
 editor = "code" # Optional: code, nvim, hx, etc.
+apply_date_prefix = true # optional, default is false
 
 # Theme configuration (choose one of the available themes)
 theme = "Catppuccin Mocha"

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,7 @@ pub struct Config {
     pub theme: Option<String>,
     pub colors: Option<ThemeConfig>,
     pub editor: Option<String>,
+    pub apply_date_prefix: Option<bool>,
 }
 
 pub fn get_file_config_toml_name() -> String {
@@ -112,7 +113,14 @@ pub fn load_file_config_toml_if_exists() -> Option<Config> {
     None
 }
 
-pub fn load_configuration() -> (PathBuf, Theme, Option<String>, bool, Option<PathBuf>) {
+pub fn load_configuration() -> (
+    PathBuf,
+    Theme,
+    Option<String>,
+    bool,
+    Option<PathBuf>,
+    Option<bool>,
+) {
     let default_path = dirs::home_dir()
         .expect("Folder not found")
         .join("work")
@@ -126,6 +134,7 @@ pub fn load_configuration() -> (PathBuf, Theme, Option<String>, bool, Option<Pat
         .ok()
         .or_else(|| std::env::var("EDITOR").ok());
     let mut is_first_run = false;
+    let mut apply_date_prefix = None;
 
     let loaded_config_path = if let Some(path) = std::env::var_os("TRY_CONFIG_DIR")
         .map(|p| PathBuf::from(p).join(get_file_config_toml_name()))
@@ -203,6 +212,7 @@ pub fn load_configuration() -> (PathBuf, Theme, Option<String>, bool, Option<Pat
                 icon_file: parse(colors.icon_file, def.icon_file),
             };
         }
+        apply_date_prefix = config.apply_date_prefix;
     } else {
         is_first_run = true;
     }
@@ -213,6 +223,7 @@ pub fn load_configuration() -> (PathBuf, Theme, Option<String>, bool, Option<Pat
         editor_cmd,
         is_first_run,
         loaded_config_path,
+        apply_date_prefix,
     )
 }
 
@@ -221,12 +232,14 @@ pub fn save_config(
     theme: &Theme,
     tries_path: &Path,
     editor: &Option<String>,
+    apply_date_prefix: Option<bool>,
 ) -> std::io::Result<()> {
     let config = Config {
         tries_path: Some(tries_path.to_string_lossy().to_string()),
         theme: Some(theme.name.clone()),
         colors: None,
         editor: editor.clone(),
+        apply_date_prefix,
     };
 
     let toml_string =

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,11 @@
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::SystemTime;
+
+use chrono::{Local, NaiveDate, NaiveDateTime};
+
+const DATE_PREFIX_FORMAT: &str = "%Y-%m-%d";
 
 /// Checks if current directory is inside a git repository
 pub fn is_inside_git_repo<P: AsRef<Path>>(path: P) -> bool {
@@ -122,4 +127,17 @@ pub fn get_free_disk_space_mb(path: &Path) -> Option<u64> {
 #[cfg(not(unix))]
 pub fn get_free_disk_space_mb(_path: &Path) -> Option<u64> {
     None
+}
+
+pub fn extract_prefix_date(name: &str) -> Option<(SystemTime, String)> {
+    let (lhs, rhs) = name.split_once(' ')?;
+    let naive_date = NaiveDate::parse_from_str(lhs, DATE_PREFIX_FORMAT).ok()?;
+    let dt: NaiveDateTime = naive_date.into();
+    let dt_local = dt.and_local_timezone(Local).single()?;
+    Some((dt_local.into(), rhs.into()))
+}
+
+pub fn generate_prefix_date() -> String {
+    let now = Local::now();
+    now.format("%Y-%m-%d").to_string()
 }


### PR DESCRIPTION
Fixes #18 

## Change in behavior:

### UI display (selector)

* date prefix of folder is not shown in _name_ but is used in the `created` column instead of the file system timestamp (if folder does not have a valid date prefix then the old behavior remains -> file system folder creation date is used)
* fuzzy searches the full name, so date is included
* this new behavior is independent of configuration

One catch: if you have "2026-01-20 foo" and "foo" both will show as "foo" in the UI
_should we remediate that?_ if so, any suggestions?

### try creation

* config key `apply_date_prefix = [true|false]`, default is `false`
* if `apply_date_prefix = true`:
    - entered name is prefixed with `<YYYY-mm-DD> `

### command line run

If you now have a try at `.../2026-01-20 foo` and run `try-rs foo` and the current date is _not_ 2026-01-20 anymore it will create a new try at `<today> foo`. This may be counter-intuitive. 

I thought _maybe_ it would make sense to..
- if only one `foo` folder exists: open that
- if more than one `foo` folders (at most one without date, one or more with date prefix): open the tui with `foo` prefilled
- no match: create new

I'm open for suggestions here ;) though for me it would also work the way it is right now.
