### PR TITLE
flake: add overlay, re-format with official formatter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-description = "try-rs: Temporary workspace manager with TUI";
+  description = "try-rs: Temporary workspace manager with TUI";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -7,20 +7,27 @@ description = "try-rs: Temporary workspace manager with TUI";
     rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
-        overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs {
-          inherit system overlays;
+          inherit system;
+          overlays = [ (import rust-overlay) ];
         };
       in
       {
-        packages.default = pkgs.rustPlatform.buildRustPackage {
+        packages.try-rs = pkgs.rustPlatform.buildRustPackage {
           pname = "try-rs";
-          version = "0.1.58";  # update when releasing new version
+          version = "0.1.58"; # update when releasing new version
 
-          src = self;  # uses the repo itself as source
+          src = self; # uses the repo itself as source
 
           cargoLock = {
             lockFile = ./Cargo.lock;
@@ -36,8 +43,19 @@ description = "try-rs: Temporary workspace manager with TUI";
           };
         };
 
+        packages.default = self.packages.${system}.try-rs;
+
         devShells.default = pkgs.mkShell {
-          buildInputs = [ pkgs.rust-bin.stable.latest.default pkgs.cargo ];
+          buildInputs = [
+            pkgs.rust-bin.stable.latest.default
+            pkgs.cargo
+          ];
         };
-      });
+      }
+    )
+    // {
+      overlays.default = final: prev: {
+        try-rs = self.packages.${final.system}.try-rs;
+      };
+    };
 }


### PR DESCRIPTION
Add overlay will make it easier for people to add the flake's content to their nixpkgs.

Reformatted using `nixd`.