### PR TITLE
fix: udpate version output to stdout rather than stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,11 +31,7 @@ use crate::utils::{SelectionResult, generate_prefix_date};
 fn main() -> Result<()> {
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,
-        Err(err) => {
-            let mut stderr = std::io::stderr();
-            write!(stderr, "{}", err).unwrap();
-            std::process::exit(if err.use_stderr() { 1 } else { 0 });
-        }
+        Err(err) => err.exit(),
     };
     let (
         tries_dir,


### PR DESCRIPTION
right now --version/--help goes to stderr rather than stdout, this pr is to change the behavior

- https://github.com/Homebrew/homebrew-core/pull/265653


cc @tassiovirginio