### PR TITLE
feat: add inline picker mode and fish binding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A blazing fast, Rust-based workspace manager for your temporary experiments.
 | **Safe Deletion**        | Delete old experiments via UI with confirmation (`Ctrl+D`).                            |
 | **Configurable**         | Supports XDG Base Directory (view section [Configuration](#configuration)).            |
 | **Multi-Shell Support**  | Supports Fish, Zsh, Bash, Power Shell and Nushell.                                     |
+| **Inline Picker**        | Adds support for a non-fullscreen picker.                                                 |
 | **Multi-OS Support**     | Supports Linux, macOS and Windows.                                                     |
 | **Shell Tab Completion** | Dynamic tab completion for directory names from your tries path.                       |
 | **Icons Identification** | Supports icons identification projects (` 󰬔     `).                              |
@@ -140,6 +141,19 @@ try-rs --setup fish
 ```bash
 alias try "try-rs"
 ```
+
+To bind the inline (non-fullscreen) picker to `Ctrl+T`, append this to `~/.config/fish/config.fish`:
+
+```fish
+bind \ct try-rs-picker
+bind -M insert \ct try-rs-picker
+```
+
+- Use `Ctrl+T` at the Fish prompt to open the picker and jump directly into a selected folder.
+- Optional: set `TRY_RS_PICKER_HEIGHT` to control picker height in rows (default: `18`).
+  ```fish
+  set -Ux TRY_RS_PICKER_HEIGHT 22
+  ```
 
 - Zsh
 
@@ -345,6 +359,7 @@ You can also bypass the UI:
 | `try-rs --setup <shell>`                       | Setup shell integration (fish, zsh, bash, nu-shell, power-shell)    |
 | `try-rs --setup-stdout <shell>`                | Print shell integration script to stdout (for manual setup)         |
 | `try-rs --completions <shell>`                 | Generate shell completion script for tab completion                 |
+| `try-rs --inline-picker [--inline-height <n>]` | Open the picker inline (non-fullscreen) in the current terminal     |
 | `try-rs --version`                             | Show application version                                            |
 | `try-rs --help`                                | Show help message                                                   |
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,6 +32,14 @@ pub struct Cli {
     /// Create a git worktree from current repository (must be inside a git repo)
     #[arg(short = 'w', long = "worktree", value_name = "WORKTREE_NAME")]
     pub worktree: Option<String>,
+
+    /// Render the picker inline (non-fullscreen), useful for shell key bindings
+    #[arg(long)]
+    pub inline_picker: bool,
+
+    /// Inline picker height in terminal rows (default: 18)
+    #[arg(long, value_name = "LINES", requires = "inline_picker")]
+    pub inline_height: Option<u16>,
 }
 
 #[derive(ValueEnum, Clone, Copy, PartialEq, Eq, Debug, Hash)]

--- a/test/integration_test.rs
+++ b/test/integration_test.rs
@@ -215,6 +215,7 @@ fn new_worktree() {
         .current_dir(git_dir)
         .args(["--worktree", "my-brand-new-feature"])
         .env("SHELL", "")
+        .env_remove("TRY_PATH")
         .env("TRY_CONFIG_DIR", h.dir.path())
         .output()
         .map(|output| Output {
@@ -346,6 +347,7 @@ impl Harness {
             .arg("--")
             .args(args)
             .env("SHELL", "")
+            .env_remove("TRY_PATH")
             .env("TRY_CONFIG_DIR", self.dir.path())
             .output()
             .map(|output| Output {
@@ -365,6 +367,7 @@ impl Harness {
             .arg("run")
             .arg("--")
             .args(args)
+            .env_remove("TRY_PATH")
             .env("TRY_CONFIG_DIR", self.dir.path())
             .env(env_key, env_val)
             .output()
@@ -438,6 +441,34 @@ fn help_contains_expected_flags() {
         output.contains("--worktree") || output.contains("-w"),
         "should document worktree flag"
     );
+    assert!(
+        output.contains("--inline-picker"),
+        "should document inline picker flag"
+    );
+}
+
+#[test]
+fn inline_height_requires_inline_picker() {
+    let p = Command::new("cargo")
+        .arg("run")
+        .arg("--")
+        .arg("--inline-height")
+        .arg("22")
+        .output()
+        .expect("failed to spawn");
+
+    assert!(
+        !p.status.success(),
+        "--inline-height should require --inline-picker"
+    );
+
+    let stdout = String::from_utf8(p.stdout).unwrap();
+    let stderr = String::from_utf8(p.stderr).unwrap();
+    let output = format!("{stdout}\n{stderr}");
+    assert!(
+        output.contains("--inline-picker"),
+        "error should mention missing --inline-picker"
+    );
 }
 
 #[test]
@@ -455,6 +486,10 @@ fn setup_stdout_fish() {
     assert!(
         stdout.contains("function try-rs"),
         "fish integration should define try-rs function"
+    );
+    assert!(
+        stdout.contains("function try-rs-picker"),
+        "fish integration should define picker function"
     );
 }
 

--- a/test/shell_test.rs
+++ b/test/shell_test.rs
@@ -7,6 +7,7 @@ use try_rs::shell::*;
 fn get_shell_content_fish_contains_function() {
     let content = get_shell_content(&Shell::Fish);
     assert!(content.contains("function try-rs"));
+    assert!(content.contains("function try-rs-picker"));
     assert!(content.contains("end"));
 }
 


### PR DESCRIPTION
this PR opens the door to full shell integration for QoL improvements, like the included fish integration (in this example `<ctr-t>` opens the picker)

<img width="1801" height="890" alt="image" src="https://github.com/user-attachments/assets/487906d6-e4da-4a84-b101-b27b3946765f" />
