### PR TITLE
fix: use POSIX-standard sed -E instead of GNU \? in shell completions

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -197,7 +197,7 @@ function __try_rs_get_tries_path
     for config_path in $config_paths
         if test -f $config_path
             # Try tries_path (supports single or multiple paths with comma)
-            set -l tries_path (command grep -E '^\s*tries_path\s*=' $config_path 2>/dev/null | command sed 's/.*=\s*"\?\([^"]*\)"\?.*/\1/' | command sed "s|~|$HOME|" | string trim)
+            set -l tries_path (command grep -E '^\s*tries_path\s*=' $config_path 2>/dev/null | command sed -E 's/.*=[[:space:]]*"?([^"]*)"?.*/\1/' | command sed "s|~|$HOME|" | string trim)
             if test -n "$tries_path"
                 # Check if it contains comma (multiple paths)
                 if echo "$tries_path" | command grep -q ","
@@ -249,7 +249,7 @@ _try_rs_get_tries_path() {
     for config_path in "${config_paths[@]}"; do
         if [[ -f "$config_path" ]]; then
             # Try tries_path (supports single or multiple paths with comma)
-            local tries_path=$(grep -E '^[[:space:]]*tries_path[[:space:]]*=' "$config_path" 2>/dev/null | sed 's/.*=[[:space:]]*"\?\([^"]*\)"\?.*/\1/' | sed "s|~|$HOME|" | tr -d '[:space:]')
+            local tries_path=$(grep -E '^[[:space:]]*tries_path[[:space:]]*=' "$config_path" 2>/dev/null | sed -E 's/.*=[[:space:]]*"?([^"]*)"?.*/\1/' | sed "s|~|$HOME|" | tr -d '[:space:]')
             if [[ -n "$tries_path" ]]; then
                 if [[ "$tries_path" == *","* ]]; then
                     echo "$tries_path" | tr ',' '\n'
@@ -313,7 +313,7 @@ _try_rs_get_tries_path() {
     for config_path in "${config_paths[@]}"; do
         if [[ -f "$config_path" ]]; then
             # Try tries_path (supports single or multiple paths with comma)
-            local tries_path=$(grep -E '^[[:space:]]*tries_path[[:space:]]*=' "$config_path" 2>/dev/null | sed 's/.*=[[:space:]]*"\?\([^"]*\)"\?.*/\1/' | sed "s|~|$HOME|" | tr -d '[:space:]')
+            local tries_path=$(grep -E '^[[:space:]]*tries_path[[:space:]]*=' "$config_path" 2>/dev/null | sed -E 's/.*=[[:space:]]*"?([^"]*)"?.*/\1/' | sed "s|~|$HOME|" | tr -d '[:space:]')
             if [[ -n "$tries_path" ]]; then
                 if [[ "$tries_path" == *","* ]]; then
                     echo "$tries_path" | tr ',' '\n'


### PR DESCRIPTION
## Summary

- Replaces GNU-specific `\?` BRE quantifier with POSIX-standard `?` ERE quantifier in shell completion config parsing
- Adds `sed -E` flag to enable extended regex, which has been part of the POSIX standard since POSIX.1-2024 and is supported by both GNU and BSD sed

## Problem

The `_try_rs_get_tries_path` function used `\?` (a GNU sed extension) in its basic regex, which silently fails on macOS/BSD sed. This caused the `tries_path` config value to never be extracted, so completions always fell through to the default `~/work/tries`.

## Details

`\?` means "zero or one" in GNU sed's basic regex, but is not supported by BSD sed ([GNU sed manual, "BRE vs ERE"](https://www.gnu.org/software/sed/manual/html_node/BRE-vs-ERE.html); [BSD sed(1)](https://man.openbsd.org/sed.1) — extended regex only). On macOS, `\?` is treated as a literal `?`, so the entire substitution fails.

The fix switches to extended regex (`-E`) with plain `?`, which is portable across both GNU and BSD sed. The `-E` flag is part of the POSIX standard ([IEEE Std 1003.1-2024](https://pubs.opengroup.org/onlinepubs/9799919799/)).

Closes #56.