### PR TITLE
fix: use native zsh completions and utils

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -266,33 +266,20 @@ _try_rs_get_tries_path() {
 }
 
 _try_rs_complete() {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    local tries_paths=$(_try_rs_get_tries_path)
     local -a dirs=()
-    
-    # Split by comma if multiple paths
-    IFS=',' read -ra PATH_ARRAY <<< "$tries_paths"
-    
-    for tries_path in "${PATH_ARRAY[@]}"; do
-        # Trim whitespace
-        tries_path=$(echo "$tries_path" | xargs)
-        
+    local tries_path
+
+    while IFS= read -r tries_path; do
         if [[ -d "$tries_path" ]]; then
-            # Get list of directories
-            while IFS= read -r dir; do
-                dirs+=("$dir")
-            done < <(ls -1 "$tries_path" 2>/dev/null | while read -r dir; do
-                if [[ -d "$tries_path/$dir" ]]; then
-                    echo "$dir"
-                fi
-            done)
+            local -a entries=("$tries_path"/*(N-/))
+            dirs+=("${entries[@]:t}")
         fi
-    done
-    
-    COMPREPLY=($(compgen -W "${dirs[*]}" -- "$cur"))
+    done < <(_try_rs_get_tries_path)
+
+    compadd -a dirs
 }
 
-complete -o default -F _try_rs_complete try-rs
+compdef _try_rs_complete try-rs
 "#.to_string()
         }
         Shell::Bash => {


### PR DESCRIPTION
## Summary

- Replaces bash-only completion constructs (`COMPREPLY`, `compgen`, `complete -F`) with native zsh equivalents (`compadd`, `compdef`)
- Replaces external `ls` + `while/read` directory listing with zsh glob `*(N-/) ` and `:t` modifier
- Simplifies path iteration by reading directly from `_try_rs_get_tries_path` output instead of comma-splitting with `read -ra`

## Details

The zsh completion function currently uses bash-specific syntax that only works when `bashcompinit` is loaded. This PR rewrites the completion function to use zsh-native constructs:

| Bash construct | Zsh replacement |
|---|---|
| `COMPREPLY` / `compgen` | `compadd -a` |
| `complete -F` | `compdef` |
| `ls -1` + `while/read` loop | `*(N-/)` glob + `:t` modifier |
| `read -ra` + comma-split | `while IFS= read -r` from function output |

Closes #58.