### PR TITLE
feat: add home-manager module for try-rs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,5 +59,74 @@
       overlays.default = final: prev: {
         try-rs = self.packages.${final.system}.try-rs;
       };
+
+      homeModules.default =
+        { config, lib, pkgs, ... }:
+        with lib;
+        let
+          cfg = config.programs.try-rs;
+        in
+        {
+          options.programs.try-rs = {
+            enable = mkEnableOption "try-rs - temporary workspace manager with TUI";
+
+            package = mkOption {
+              type = types.package;
+              default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+              defaultText = literalExpression "inputs.try-rs.packages.\${pkgs.stdenv.hostPlatform.system}.default";
+              description = "The try-rs package to use.";
+            };
+
+            path = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              example = "~/src/tries";
+              description = ''
+                Path where try-rs directories will be stored. When set, writes
+                `tries_paths` to `$XDG_CONFIG_HOME/try-rs/config.toml`.
+              '';
+            };
+
+            enableBashIntegration = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Whether to enable Bash integration.";
+            };
+
+            enableZshIntegration = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Whether to enable Zsh integration.";
+            };
+
+            enableFishIntegration = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Whether to enable Fish integration.";
+            };
+          };
+
+          config = mkIf cfg.enable {
+            home.packages = [ cfg.package ];
+
+            xdg.configFile."try-rs/config.toml" = mkIf (cfg.path != null) {
+              text = ''
+                tries_paths = "${cfg.path}"
+              '';
+            };
+
+            programs.bash.initExtra = mkIf (cfg.enableBashIntegration && config.programs.bash.enable) ''
+              eval "$(${cfg.package}/bin/try-rs --setup-stdout bash)"
+            '';
+
+            programs.zsh.initContent = mkIf (cfg.enableZshIntegration && config.programs.zsh.enable) ''
+              eval "$(${cfg.package}/bin/try-rs --setup-stdout zsh)"
+            '';
+
+            programs.fish.shellInit = mkIf (cfg.enableFishIntegration && config.programs.fish.enable) ''
+              ${cfg.package}/bin/try-rs --setup-stdout fish | source
+            '';
+          };
+        };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,10 @@
         with lib;
         let
           cfg = config.programs.try-rs;
+          mkInitScript = shell:
+            pkgs.runCommand "try-rs-init.${shell}" { } ''
+              ${cfg.package}/bin/try-rs --setup-stdout ${shell} > $out
+            '';
         in
         {
           options.programs.try-rs = {
@@ -116,15 +120,15 @@
             };
 
             programs.bash.initExtra = mkIf (cfg.enableBashIntegration && config.programs.bash.enable) ''
-              eval "$(${cfg.package}/bin/try-rs --setup-stdout bash)"
+              source ${mkInitScript "bash"}
             '';
 
             programs.zsh.initContent = mkIf (cfg.enableZshIntegration && config.programs.zsh.enable) ''
-              eval "$(${cfg.package}/bin/try-rs --setup-stdout zsh)"
+              source ${mkInitScript "zsh"}
             '';
 
             programs.fish.shellInit = mkIf (cfg.enableFishIntegration && config.programs.fish.enable) ''
-              ${cfg.package}/bin/try-rs --setup-stdout fish | source
+              source ${mkInitScript "fish"}
             '';
           };
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,10 +327,18 @@ fn main() -> Result<()> {
         resolve_visibility(cli.show_right_panel, cli.hide_right_panel, show_right_panel);
     let right_panel_width = right_panel_width.unwrap_or(25).clamp(10, 90);
 
-    let tries_dir = tries_dirs[active_tab].clone();
+    // Handle output-only / config-only short-circuits before touching the
+    // tries directory. These must work in environments where HOME is not
+    // writable (e.g. the Nix build sandbox invoking `--setup-stdout` to
+    // generate shell init scripts at build time).
+    if let Some(shell) = cli.setup_stdout {
+        print!("{}", get_shell_content(&shell));
+        return Ok(());
+    }
 
-    if !tries_dir.exists() {
-        fs::create_dir_all(&tries_dir)?;
+    if let Some(shell) = cli.completions {
+        generate_completions(&shell)?;
+        return Ok(());
     }
 
     if let Some(shell) = cli.setup {
@@ -343,14 +351,10 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    if let Some(shell) = cli.setup_stdout {
-        print!("{}", get_shell_content(&shell));
-        return Ok(());
-    }
+    let tries_dir = tries_dirs[active_tab].clone();
 
-    if let Some(shell) = cli.completions {
-        generate_completions(&shell)?;
-        return Ok(());
+    if !tries_dir.exists() {
+        fs::create_dir_all(&tries_dir)?;
     }
 
     if let Some(ref worktree_branch_name) = cli.worktree {


### PR DESCRIPTION
For now the module adds try-rs to home.packages and adds shell setup for bash, zsh and fish (by relying on programs.<shell>.<...> and try-rs --setup-stdout <shell>)
Im open to adding documentation if you guys dont want to trash this PR. 