### PR TITLE
fix(powershell): replace stdout subshell capture with file redirect

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -122,12 +122,19 @@ function try-rs {{
         }}
     }}
 
-    # Captures the output of the binary (stdout) which is the "cd" or editor command
+    # Use file redirect to capture the output path from try-rs.exe.
     # The TUI is rendered on stderr, so it doesn't interfere.
-    $command = (try-rs.exe @args)
-
+    # On Windows, capturing stdout with $(try-rs.exe @args) can fail after the
+    # TUI exits raw mode / alternate screen, causing the "cd" command to print
+    # to the terminal instead of being evaluated. File redirect (>) is a
+    # kernel-level handle redirect set up before the process starts, so it
+    # is not affected by console mode changes.
+    $tempFile = [System.IO.Path]::GetTempFileName()
+    try-rs.exe @args > $tempFile
+    $command = Get-Content $tempFile -Raw
+    Remove-Item $tempFile -ErrorAction SilentlyContinue
     if ($command) {{
-        Invoke-Expression $command
+        Invoke-Expression $command.Trim()
     }}
 }}
 


### PR DESCRIPTION
## Problem
 
On Windows PowerShell, pressing Enter on a folder in the TUI prints
`cd <path>` to the terminal instead of auto-executing it. The shell
wrapper uses `$(try-rs.exe @args)` to capture stdout, but after the
TUI exits raw mode and alternate screen, stdout capture can fail —
leaving the `cd` command printed and not evaluated.
 
## Solution
 
Replace the subshell capture with PowerShell's file redirect (`>`).
This is a kernel-level handle redirect set up before the process
starts, so console mode changes from the TUI's raw mode cannot
interfere with it.
 
A unique temp file name is generated via
`[System.IO.Path]::GetTempFileName()` to prevent collisions when
multiple `try-rs` instances run concurrently.
 
## Changes
 
Only one file modified — `src/shell.rs`. The Rust binary is
untouched. This is purely a PowerShell wrapper fix, no impact on
Linux, macOS, or other shells (bash, zsh, fish, nushell).
 
## How to test?
 
1. Run `try-rs --setup power-shell` and reload profile
2. Open the TUI with `try-rs`, select a folder, press Enter
3. Confirm it automatically `cd`s into the selected folder
4. Open two terminal windows, run `try-rs` in both simultaneously
   — both should work without errors